### PR TITLE
Fix the prediction scores output by the Top K recommendations

### DIFF
--- a/src/libfm/src/fm_learn_sgd_element_BPR_blocks_compute_ranked_list_parallel.h
+++ b/src/libfm/src/fm_learn_sgd_element_BPR_blocks_compute_ranked_list_parallel.h
@@ -46,7 +46,7 @@ void *computeRankedList(void *threadarg){
 	int counter = 0;
 	for (int i = 0; i< t_data->num_sampled_cases; i++){
 		if (std::find(t_data->pos_values, t_data->pos_values+t_data->pos_observations, i) == t_data->pos_values+t_data->pos_observations){
-			uint& sampled_block_id = t_data->train.relation(SAMPLED_BLOCK).data_row_to_relation_row(i);
+			uint sampled_block_id = i;
 			sparse_row<DATA_FLOAT> sampled_block =  t_data->train.relation(SAMPLED_BLOCK).data->data->get(sampled_block_id);
 			double p = t_data->fm->predict_case_blocks(fixed_block,sampled_block,t_data->a_sampled_offsets);
 			weighted_tag[counter].tag_id = i;


### PR DESCRIPTION
I was experimenting with the BPR example and I could not manually recreate the predictions output by the Top K code using the vector data.  I think I found a bug in how the Top K predictions are created and after making this change I can manually recreate the predictions from the output vectors.